### PR TITLE
Fix incorrect CTA in market footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { Tab } from "./components/Tab";
 import { OldTradeWallet } from "./components/trade/OldTradeWallet";
 import { TradeWalletMenu } from "./components/trade/TradeWalletMenu";
 import { Button, Card, EmptyState, TooltipProvider } from "./components/ui";
-import { BookIcon, ExternalIcon } from "./components/ui/icons";
+import { BookIcon } from "./components/ui/icons";
 import { WalletConnect } from "./components/WalletConnect";
 import { localStoragePersister, queryClient, shouldDehydrateQuery } from "./config/queryClient";
 import { config } from "./config/wagmi";
@@ -161,24 +161,6 @@ const AppContent: React.FC = () => {
             <div style={{ display: view === "markets" ? "block" : "none" }} className="space-y-6">
               <ReadinessRail />
               <Tab />
-
-              <div className="flex flex-col gap-3 rounded-lg bg-surface px-6 py-5 shadow-card sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <p className="text-lede font-semibold text-ink">Trading one market at a time?</p>
-                  <p className="mt-1 text-body text-ink-3">
-                    Seer has the individual market view, liquidity provision and full analytics.
-                  </p>
-                </div>
-                <a
-                  href="https://app.seer.pm/markets/10/what-will-be-the-juror-weight-computed-through-huber-loss-minimization-in-the-lo-2"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex shrink-0 items-center gap-1.5 text-body font-semibold text-primary transition-colors hover:text-primary-hover"
-                >
-                  Open Seer
-                  <ExternalIcon width={13} height={13} />
-                </a>
-              </div>
             </div>
           )}
 

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,6 +1,6 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Badge, Button, Card, EmptyState, StatusDot } from "@/components/ui";
-import { CheckIcon, ChevronDownIcon } from "@/components/ui/icons";
+import { CheckIcon, ChevronDownIcon, ExternalIcon } from "@/components/ui/icons";
 import { ContestProvider } from "./contest/ContestContext";
 import ErrorBoundary from "./ErrorBoundary";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
@@ -61,6 +61,10 @@ export const Tab = () => {
   };
 
   const activeArchived = ARCHIVED_TABS.find((tab) => tab.id === activeTab);
+  const activeContest = TABS.find((tab) => tab.id === activeTab);
+  // If the contest is a collection of markets, it will contain marketIds instead
+  const activeMarketId =
+    activeContest && "marketId" in activeContest ? activeContest.marketId : undefined;
 
   return (
     <div className="w-full">
@@ -159,6 +163,29 @@ export const Tab = () => {
           ) : null,
         )}
       </div>
+
+      {/* Seer's address route redirects to its canonical title URL. Using the address means this
+          CTA stays correct even when Seer changes a market's title/slug. Contests that are a collection of markets, 
+          eg Zcash, intentionally has no single market destination here. */}
+      {activeMarketId && (
+        <div className="mt-6 flex flex-col gap-3 rounded-lg bg-surface px-6 py-5 shadow-card sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-lede font-semibold text-ink">Trading one market at a time?</p>
+            <p className="mt-1 text-body text-ink-3">
+              Seer has the individual market view, liquidity provision and full analytics.
+            </p>
+          </div>
+          <a
+            href={`https://app.seer.pm/markets/10/${activeMarketId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex shrink-0 items-center gap-1.5 text-body font-semibold text-primary transition-colors hover:text-primary-hover"
+          >
+            Open Seer
+            <ExternalIcon width={13} height={13} />
+          </a>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -164,9 +164,8 @@ export const Tab = () => {
         )}
       </div>
 
-      {/* Seer's address route redirects to its canonical title URL. Using the address means this
-          CTA stays correct even when Seer changes a market's title/slug. Contests that are a collection of markets, 
-          eg Zcash, intentionally has no single market destination here. */}
+      {/* Link directly to the host market id. Contests that are a collection of markets, 
+          eg Zcash, intentionally has no single market destination here, and instead link in their table */}
       {activeMarketId && (
         <div className="mt-6 flex flex-col gap-3 rounded-lg bg-surface px-6 py-5 shadow-card sm:flex-row sm:items-center sm:justify-between">
           <div>

--- a/src/components/ZcashMarketTable.tsx
+++ b/src/components/ZcashMarketTable.tsx
@@ -101,6 +101,15 @@ const ZcashMarketTableInner: React.FC<MarketTableProps> = ({
                   >
                     {market.project}
                   </span>
+                  <a
+                    href={`https://app.seer.pm/markets/10/${market.marketId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-1 inline-flex items-center gap-1 text-label font-semibold text-primary transition-colors hover:text-primary-hover"
+                  >
+                    Open Seer
+                    <ExternalIcon width={12} height={12} />
+                  </a>
                 </Td>
                 <Td>
                   <OutcomeBar yes={market.yesPrice} no={market.noPrice} />


### PR DESCRIPTION
The old link to Seer did not match the market you were viewing. This updates the footer to match the market you are looking at. If you are looking at a contest with a collection of markets, ie zcash, the footer is hidden and instead each table row has a link to that market
<img width="2156" height="1297" alt="Screenshot 2026-08-25 at 12 23 42 PM" src="https://github.com/user-attachments/assets/bbae215b-7675-41a7-8900-45e502c31b75" />
